### PR TITLE
Facilitate use of the AOB as a library

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -40,23 +40,28 @@ impl Processor {
         match instruction {
             AgnosticOrderbookInstruction::CreateMarket(params) => {
                 msg!("Instruction: Create Market");
-                create_market::process(program_id, accounts, params)?;
+                let accounts = create_market::Accounts::parse(program_id, accounts)?;
+                create_market::process(accounts, params)?;
             }
             AgnosticOrderbookInstruction::NewOrder(params) => {
                 msg!("Instruction: New Order");
-                new_order::process(program_id, accounts, params)?;
+                let accounts = new_order::Accounts::parse(program_id, accounts)?;
+                new_order::process(accounts, params)?;
             }
             AgnosticOrderbookInstruction::ConsumeEvents(params) => {
                 msg!("Instruction: Consume Events");
-                consume_events::process(program_id, accounts, params)?;
+                let accounts = consume_events::Accounts::parse(program_id, accounts)?;
+                consume_events::process(accounts, params)?;
             }
             AgnosticOrderbookInstruction::CancelOrder(params) => {
                 msg!("Instruction: Cancel Order");
-                cancel_order::process(program_id, accounts, params)?;
+                let accounts = cancel_order::Accounts::parse(program_id, accounts)?;
+                cancel_order::process(accounts, params)?;
             }
             AgnosticOrderbookInstruction::CloseMarket => {
                 msg!("Instruction: Close Market");
-                close_market::process(program_id, accounts)?;
+                let accounts = close_market::Accounts::parse(program_id, accounts)?;
+                close_market::process(accounts)?;
             }
         }
         Ok(())

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -6,15 +6,10 @@ use solana_program::{
 
 use crate::instruction::AgnosticOrderbookInstruction;
 
-#[allow(missing_docs)]
 pub mod cancel_order;
-#[allow(missing_docs)]
 pub mod close_market;
-#[allow(missing_docs)]
 pub mod consume_events;
-#[allow(missing_docs)]
 pub mod create_market;
-#[allow(missing_docs)]
 pub mod new_order;
 
 #[allow(missing_docs)]
@@ -40,28 +35,28 @@ impl Processor {
         match instruction {
             AgnosticOrderbookInstruction::CreateMarket(params) => {
                 msg!("Instruction: Create Market");
-                let accounts = create_market::Accounts::parse(program_id, accounts)?;
-                create_market::process(accounts, params)?;
+                let accounts = create_market::Accounts::parse(accounts)?;
+                create_market::process(program_id, accounts, params)?;
             }
             AgnosticOrderbookInstruction::NewOrder(params) => {
                 msg!("Instruction: New Order");
-                let accounts = new_order::Accounts::parse(program_id, accounts)?;
-                new_order::process(accounts, params)?;
+                let accounts = new_order::Accounts::parse(accounts)?;
+                new_order::process(program_id, accounts, params)?;
             }
             AgnosticOrderbookInstruction::ConsumeEvents(params) => {
                 msg!("Instruction: Consume Events");
-                let accounts = consume_events::Accounts::parse(program_id, accounts)?;
-                consume_events::process(accounts, params)?;
+                let accounts = consume_events::Accounts::parse(accounts)?;
+                consume_events::process(program_id, accounts, params)?;
             }
             AgnosticOrderbookInstruction::CancelOrder(params) => {
                 msg!("Instruction: Cancel Order");
-                let accounts = cancel_order::Accounts::parse(program_id, accounts)?;
-                cancel_order::process(accounts, params)?;
+                let accounts = cancel_order::Accounts::parse(accounts)?;
+                cancel_order::process(program_id, accounts, params)?;
             }
             AgnosticOrderbookInstruction::CloseMarket => {
                 msg!("Instruction: Close Market");
-                let accounts = close_market::Accounts::parse(program_id, accounts)?;
-                close_market::process(accounts)?;
+                let accounts = close_market::Accounts::parse(accounts)?;
+                close_market::process(program_id, accounts)?;
             }
         }
         Ok(())

--- a/program/src/processor/cancel_order.rs
+++ b/program/src/processor/cancel_order.rs
@@ -1,3 +1,5 @@
+//! Cancel an existing order in the orderbook.
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
@@ -23,19 +25,22 @@ pub struct Params {
     pub order_id: u128,
 }
 
+/// The required accounts for a cancel_order instruction.
 pub struct Accounts<'a, 'b: 'a> {
-    market: &'a AccountInfo<'b>,
-    event_queue: &'a AccountInfo<'b>,
-    bids: &'a AccountInfo<'b>,
-    asks: &'a AccountInfo<'b>,
-    authority: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub market: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub event_queue: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub bids: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub asks: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub authority: &'a AccountInfo<'b>,
 }
 
 impl<'a, 'b: 'a> Accounts<'a, 'b> {
-    pub fn parse(
-        program_id: &Pubkey,
-        accounts: &'a [AccountInfo<'b>],
-    ) -> Result<Self, ProgramError> {
+    pub(crate) fn parse(accounts: &'a [AccountInfo<'b>]) -> Result<Self, ProgramError> {
         let accounts_iter = &mut accounts.iter();
 
         let a = Self {
@@ -45,20 +50,30 @@ impl<'a, 'b: 'a> Accounts<'a, 'b> {
             asks: next_account_info(accounts_iter)?,
             authority: next_account_info(accounts_iter)?,
         };
-        check_account_owner(a.market, &program_id.to_bytes(), AoError::WrongMarketOwner)?;
+        Ok(a)
+    }
+
+    /// Perform basic security checks on the accounts
+    pub(crate) fn perform_checks(&self, program_id: &Pubkey) -> Result<(), ProgramError> {
         check_account_owner(
-            a.event_queue,
+            self.market,
+            &program_id.to_bytes(),
+            AoError::WrongMarketOwner,
+        )?;
+        check_account_owner(
+            self.event_queue,
             &program_id.to_bytes(),
             AoError::WrongEventQueueOwner,
         )?;
-        check_account_owner(a.bids, &program_id.to_bytes(), AoError::WrongBidsOwner)?;
-        check_account_owner(a.asks, &program_id.to_bytes(), AoError::WrongAsksOwner)?;
-        check_signer(a.authority)?;
-        Ok(a)
+        check_account_owner(self.bids, &program_id.to_bytes(), AoError::WrongBidsOwner)?;
+        check_account_owner(self.asks, &program_id.to_bytes(), AoError::WrongAsksOwner)?;
+        check_signer(self.authority)?;
+        Ok(())
     }
 }
-
-pub(crate) fn process(accounts: Accounts, params: Params) -> ProgramResult {
+/// Apply the cancel_order instruction to the provided accounts
+pub fn process(program_id: &Pubkey, accounts: Accounts, params: Params) -> ProgramResult {
+    accounts.perform_checks(program_id)?;
     let market_state = MarketState::get(&accounts.market)?;
 
     check_accounts(&accounts, &market_state)?;

--- a/program/src/processor/cancel_order.rs
+++ b/program/src/processor/cancel_order.rs
@@ -23,7 +23,7 @@ pub struct Params {
     pub order_id: u128,
 }
 
-struct Accounts<'a, 'b: 'a> {
+pub struct Accounts<'a, 'b: 'a> {
     market: &'a AccountInfo<'b>,
     event_queue: &'a AccountInfo<'b>,
     bids: &'a AccountInfo<'b>,
@@ -58,13 +58,7 @@ impl<'a, 'b: 'a> Accounts<'a, 'b> {
     }
 }
 
-pub(crate) fn process(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
-    params: Params,
-) -> ProgramResult {
-    let accounts = Accounts::parse(program_id, accounts)?;
-
+pub(crate) fn process(accounts: Accounts, params: Params) -> ProgramResult {
     let market_state = MarketState::get(&accounts.market)?;
 
     check_accounts(&accounts, &market_state)?;

--- a/program/src/processor/close_market.rs
+++ b/program/src/processor/close_market.rs
@@ -19,7 +19,7 @@ The required arguments for a close_market instruction.
 */
 pub struct Params {}
 
-struct Accounts<'a, 'b: 'a> {
+pub struct Accounts<'a, 'b: 'a> {
     market: &'a AccountInfo<'b>,
     event_queue: &'a AccountInfo<'b>,
     bids: &'a AccountInfo<'b>,
@@ -48,9 +48,7 @@ impl<'a, 'b: 'a> Accounts<'a, 'b> {
     }
 }
 
-pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let accounts = Accounts::parse(program_id, accounts)?;
-
+pub(crate) fn process(accounts: Accounts) -> ProgramResult {
     let mut market_state = MarketState::get(&accounts.market)?;
 
     check_accounts(&accounts, &market_state)?;

--- a/program/src/processor/close_market.rs
+++ b/program/src/processor/close_market.rs
@@ -1,3 +1,4 @@
+//! Close an existing market.
 use crate::{
     error::AoError,
     orderbook::OrderBookState,
@@ -19,20 +20,24 @@ The required arguments for a close_market instruction.
 */
 pub struct Params {}
 
+/// The required accounts for a close_market instruction.
 pub struct Accounts<'a, 'b: 'a> {
-    market: &'a AccountInfo<'b>,
-    event_queue: &'a AccountInfo<'b>,
-    bids: &'a AccountInfo<'b>,
-    asks: &'a AccountInfo<'b>,
-    authority: &'a AccountInfo<'b>,
-    lamports_target_account: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub market: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub event_queue: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub bids: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub asks: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub authority: &'a AccountInfo<'b>,
+    #[allow(missing_docs)]
+    pub lamports_target_account: &'a AccountInfo<'b>,
 }
 
 impl<'a, 'b: 'a> Accounts<'a, 'b> {
-    pub fn parse(
-        program_id: &Pubkey,
-        accounts: &'a [AccountInfo<'b>],
-    ) -> Result<Self, ProgramError> {
+    pub(crate) fn parse(accounts: &'a [AccountInfo<'b>]) -> Result<Self, ProgramError> {
         let accounts_iter = &mut accounts.iter();
         let a = Self {
             market: next_account_info(accounts_iter)?,
@@ -42,13 +47,22 @@ impl<'a, 'b: 'a> Accounts<'a, 'b> {
             authority: next_account_info(accounts_iter)?,
             lamports_target_account: next_account_info(accounts_iter)?,
         };
-        check_account_owner(a.market, &program_id.to_bytes(), AoError::WrongMarketOwner)?;
-        check_signer(a.authority)?;
         Ok(a)
     }
-}
 
-pub(crate) fn process(accounts: Accounts) -> ProgramResult {
+    pub(crate) fn perform_checks(&self, program_id: &Pubkey) -> Result<(), ProgramError> {
+        check_account_owner(
+            self.market,
+            &program_id.to_bytes(),
+            AoError::WrongMarketOwner,
+        )?;
+        check_signer(self.authority)?;
+        Ok(())
+    }
+}
+/// Apply the close_market instruction to the provided accounts
+pub fn process(program_id: &Pubkey, accounts: Accounts) -> ProgramResult {
+    accounts.perform_checks(program_id)?;
     let mut market_state = MarketState::get(&accounts.market)?;
 
     check_accounts(&accounts, &market_state)?;

--- a/program/src/processor/consume_events.rs
+++ b/program/src/processor/consume_events.rs
@@ -22,7 +22,7 @@ pub struct Params {
     pub number_of_entries_to_consume: u64,
 }
 
-struct Accounts<'a, 'b: 'a> {
+pub struct Accounts<'a, 'b: 'a> {
     market: &'a AccountInfo<'b>,
     event_queue: &'a AccountInfo<'b>,
     authority: &'a AccountInfo<'b>,
@@ -56,13 +56,7 @@ impl<'a, 'b: 'a> Accounts<'a, 'b> {
     }
 }
 
-pub(crate) fn process(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
-    params: Params,
-) -> ProgramResult {
-    let accounts = Accounts::parse(program_id, accounts)?;
-
+pub(crate) fn process(accounts: Accounts, params: Params) -> ProgramResult {
     let mut market_state = MarketState::get(&accounts.market)?;
 
     check_accounts(&accounts, &market_state)?;

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -38,7 +38,7 @@ pub struct Params {
     pub cranker_reward: u64,
 }
 
-struct Accounts<'a, 'b: 'a> {
+pub struct Accounts<'a, 'b: 'a> {
     market: &'a AccountInfo<'b>,
     event_queue: &'a AccountInfo<'b>,
     bids: &'a AccountInfo<'b>,
@@ -71,13 +71,7 @@ impl<'a, 'b: 'a> Accounts<'a, 'b> {
     }
 }
 
-pub(crate) fn process(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
-    params: Params,
-) -> ProgramResult {
-    let accounts = Accounts::parse(program_id, accounts)?;
-
+pub(crate) fn process(accounts: Accounts, params: Params) -> ProgramResult {
     let Params {
         caller_authority,
         callback_info_len,

--- a/program/src/processor/new_order.rs
+++ b/program/src/processor/new_order.rs
@@ -48,7 +48,7 @@ pub struct Params {
     pub self_trade_behavior: SelfTradeBehavior,
 }
 
-struct Accounts<'a, 'b: 'a> {
+pub struct Accounts<'a, 'b: 'a> {
     market: &'a AccountInfo<'b>,
     event_queue: &'a AccountInfo<'b>,
     bids: &'a AccountInfo<'b>,
@@ -85,12 +85,7 @@ impl<'a, 'b: 'a> Accounts<'a, 'b> {
     }
 }
 
-pub(crate) fn process(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
-    mut params: Params,
-) -> ProgramResult {
-    let accounts = Accounts::parse(program_id, accounts)?;
+pub(crate) fn process(accounts: Accounts, mut params: Params) -> ProgramResult {
     let mut market_state = MarketState::get(&accounts.market)?;
 
     check_accounts(&accounts, &market_state)?;


### PR DESCRIPTION
This draft PR will incorporate changes to facilitate the use of the AOB as a third-party library. This will enable optimizations of the compute budget.