### PR TITLE
Implement price ticks

### DIFF
--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -40,6 +40,7 @@ export const createMarket = async (
   nodesCapacity: number,
   minOrderSize: BN,
   feePayer: PublicKey,
+  priceBitMask: BN,
   programId?: PublicKey
 ): Promise<PrimedTransaction> => {
   if (programId === undefined) {
@@ -113,6 +114,7 @@ export const createMarket = async (
     callBackInfoLen,
     callBackIdLen,
     minOrderSize,
+    priceBitMask,
   }).getInstruction(
     programId,
     market.publicKey,

--- a/js/src/instructions.ts
+++ b/js/src/instructions.ts
@@ -10,6 +10,7 @@ export class createMarketInstruction {
   callBackInfoLen: BN;
   callBackIdLen: BN;
   minOrderSize: BN;
+  priceBitMask: BN;
 
   static schema: Schema = new Map([
     [
@@ -22,6 +23,7 @@ export class createMarketInstruction {
           ["callBackInfoLen", "u64"],
           ["callBackIdLen", "u64"],
           ["minOrderSize", "u64"],
+          ["priceBitMask", "u64"],
         ],
       },
     ],
@@ -32,12 +34,14 @@ export class createMarketInstruction {
     callBackInfoLen: BN;
     callBackIdLen: BN;
     minOrderSize: BN;
+    priceBitMask: BN;
   }) {
     this.tag = 0;
     this.callerAuthority = obj.callerAuthority;
     this.callBackInfoLen = obj.callBackInfoLen;
     this.callBackIdLen = obj.callBackIdLen;
     this.minOrderSize = obj.minOrderSize;
+    this.priceBitMask = obj.priceBitMask;
   }
 
   serialize(): Uint8Array {

--- a/js/src/market_state.ts
+++ b/js/src/market_state.ts
@@ -37,6 +37,7 @@ export class MarketState {
   feeBudget: BN;
   initialLamports: BN;
   minOrderSize: BN;
+  priceBitMask: BN;
 
   static LEN: number = 176;
 
@@ -56,6 +57,7 @@ export class MarketState {
           ["feeBudget", "u64"],
           ["initialLamports", "u64"],
           ["minOrderSize", "u64"],
+          ["priceBitMask", "u64"],
         ],
       },
     ],
@@ -72,6 +74,7 @@ export class MarketState {
     feeBudget: BN;
     initialLamports: BN;
     minOrderSize: BN;
+    priceBitMask: BN;
   }) {
     this.tag = arg.tag as AccountTag;
     this.callerAuthority = new PublicKey(arg.callerAuthority);
@@ -83,6 +86,7 @@ export class MarketState {
     this.feeBudget = arg.feeBudget;
     this.initialLamports = arg.initialLamports;
     this.minOrderSize = arg.minOrderSize;
+    this.priceBitMask = arg.priceBitMask;
   }
 
   /**

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -58,7 +58,7 @@ pub enum AgnosticOrderbookInstruction {
     /// | 3     | ✅       | ❌     | The asks account        |
     /// | 4     | ❌       | ✅     | The caller authority    |
     CancelOrder(cancel_order::Params),
-    /// Close and existing market.
+    /// Close an existing market.
     ///
     /// Required accounts
     ///

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -2,6 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
+    msg,
     program_error::ProgramError,
     pubkey::Pubkey,
 };
@@ -89,6 +90,11 @@ pub(crate) fn process(
     check_unitialized(accounts.market)?;
 
     let mut market_state = MarketState::get_unchecked(accounts.market);
+
+    if price_bitmask.leading_ones() + price_bitmask.trailing_zeros() != 64 {
+        msg!("The provided bitmask is invalid");
+        return Err(ProgramError::InvalidArgument);
+    }
 
     *market_state = MarketState {
         tag: AccountTag::Market as u64,

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -31,6 +31,8 @@ pub struct Params {
     pub callback_id_len: u64,
     /// The minimum order size that can be inserted into the orderbook after matching.
     pub min_base_order_size: u64,
+    /// Enables the limiting of price precision on the orderbook (price ticks)
+    pub price_bitmask: u64,
 }
 
 struct Accounts<'a, 'b: 'a> {
@@ -78,6 +80,7 @@ pub(crate) fn process(
         callback_info_len,
         callback_id_len,
         min_base_order_size,
+        price_bitmask,
     } = params;
 
     check_unitialized(accounts.event_queue)?;
@@ -98,6 +101,7 @@ pub(crate) fn process(
         fee_budget: 0,
         initial_lamports: accounts.market.lamports(),
         min_base_order_size,
+        price_bitmask,
     };
 
     let event_queue_header = EventQueueHeader::initialize(params.callback_info_len as usize);

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -91,7 +91,7 @@ pub(crate) fn process(
 
     let mut market_state = MarketState::get_unchecked(accounts.market);
     // Checks that the bitmask is of the form 1111...11100...00 (all ones then all zeros)
-    if price_bitmask.leading_ones() + price_bitmask.trailing_zeros() != 64 {
+    if u64::MAX << price_bitmask.trailing_zeros() != price_bitmask {
         msg!("The provided bitmask is invalid");
         return Err(ProgramError::InvalidArgument);
     }

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -90,7 +90,7 @@ pub(crate) fn process(
     check_unitialized(accounts.market)?;
 
     let mut market_state = MarketState::get_unchecked(accounts.market);
-
+    // Checks that the bitmask is of the form 1111...11100...00 (all ones then all zeros)
     if price_bitmask.leading_ones() + price_bitmask.trailing_zeros() != 64 {
         msg!("The provided bitmask is invalid");
         return Err(ProgramError::InvalidArgument);

--- a/program/src/processor/new_order.rs
+++ b/program/src/processor/new_order.rs
@@ -89,12 +89,15 @@ impl<'a, 'b: 'a> Accounts<'a, 'b> {
 pub(crate) fn process(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
-    params: Params,
+    mut params: Params,
 ) -> ProgramResult {
     let accounts = Accounts::parse(program_id, accounts)?;
     let mut market_state = MarketState::get(&accounts.market)?;
 
     check_accounts(&accounts, &market_state)?;
+
+    // Floor price to nearest valid price tick
+    params.limit_price &= market_state.price_bitmask;
 
     let callback_info_len = market_state.callback_info_len as usize;
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -87,7 +87,8 @@ pub struct MarketState {
     pub initial_lamports: u64,
     /// The minimum order size that can be inserted into the orderbook after matching.
     pub min_base_order_size: u64,
-    //TODO cranked_accs
+    /// Enables the limiting of price precision on the orderbook (price ticks)
+    pub price_bitmask: u64,
 }
 
 /// Expected size in bytes of MarketState

--- a/program/tests/common/utils.rs
+++ b/program/tests/common/utils.rs
@@ -93,6 +93,7 @@ pub async fn create_market_and_accounts(
             callback_info_len: 32,
             callback_id_len: 32,
             min_base_order_size: 10,
+            price_bitmask: u64::MAX,
         },
     );
     sign_send_instructions(&mut prg_test_ctx, vec![create_market_instruction], vec![])


### PR DESCRIPTION
This PR enables protection of the AOB against order priority exploits involving excessive available precision for asset prices.

This protection is implemented as a configurable bit mask to ignore a certain number of least significant bits in the FP32 price.