### PR TITLE
Add customizable cranker rewards to market state

### DIFF
--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -41,6 +41,7 @@ export const createMarket = async (
   minOrderSize: BN,
   feePayer: PublicKey,
   priceBitMask: BN,
+  crankerReward: BN,
   programId?: PublicKey
 ): Promise<PrimedTransaction> => {
   if (programId === undefined) {
@@ -115,6 +116,7 @@ export const createMarket = async (
     callBackIdLen,
     minOrderSize,
     priceBitMask,
+    crankerReward,
   }).getInstruction(
     programId,
     market.publicKey,

--- a/js/src/instructions.ts
+++ b/js/src/instructions.ts
@@ -11,6 +11,7 @@ export class createMarketInstruction {
   callBackIdLen: BN;
   minOrderSize: BN;
   priceBitMask: BN;
+  crankerReward: BN;
 
   static schema: Schema = new Map([
     [
@@ -24,6 +25,7 @@ export class createMarketInstruction {
           ["callBackIdLen", "u64"],
           ["minOrderSize", "u64"],
           ["priceBitMask", "u64"],
+          ["crankerReward", "u64"],
         ],
       },
     ],
@@ -35,6 +37,7 @@ export class createMarketInstruction {
     callBackIdLen: BN;
     minOrderSize: BN;
     priceBitMask: BN;
+    crankerReward: BN;
   }) {
     this.tag = 0;
     this.callerAuthority = obj.callerAuthority;
@@ -42,6 +45,7 @@ export class createMarketInstruction {
     this.callBackIdLen = obj.callBackIdLen;
     this.minOrderSize = obj.minOrderSize;
     this.priceBitMask = obj.priceBitMask;
+    this.crankerReward = obj.crankerReward;
   }
 
   serialize(): Uint8Array {

--- a/js/src/market_state.ts
+++ b/js/src/market_state.ts
@@ -38,8 +38,9 @@ export class MarketState {
   initialLamports: BN;
   minOrderSize: BN;
   priceBitMask: BN;
+  crankerReward: BN;
 
-  static LEN: number = 176;
+  static LEN: number = 184;
 
   static schema: Schema = new Map([
     [
@@ -58,6 +59,7 @@ export class MarketState {
           ["initialLamports", "u64"],
           ["minOrderSize", "u64"],
           ["priceBitMask", "u64"],
+          ["crankerReward", "u64"],
         ],
       },
     ],
@@ -75,6 +77,7 @@ export class MarketState {
     initialLamports: BN;
     minOrderSize: BN;
     priceBitMask: BN;
+    crankerReward: BN;
   }) {
     this.tag = arg.tag as AccountTag;
     this.callerAuthority = new PublicKey(arg.callerAuthority);
@@ -87,6 +90,7 @@ export class MarketState {
     this.initialLamports = arg.initialLamports;
     this.minOrderSize = arg.minOrderSize;
     this.priceBitMask = arg.priceBitMask;
+    this.crankerReward = arg.crankerReward;
   }
 
   /**

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -62,13 +62,4 @@ pub(crate) mod orderbook;
 pub(crate) mod processor;
 pub(crate) mod utils;
 
-////////////////////////////////////////////////////////////
-// Constants
-
-/// The minimum fee that is payed for opening an order.
-/// Fees are payed out to consume event crankers.
-pub const CRANKER_REWARD: u64 = 1_000;
-
-////////////////////////////////////////////////////////////
-
 declare_id!("aaobKniTtDGvCZces7GH5UReLYP671bBkB96ahr9x3e");

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -34,6 +34,8 @@ pub struct Params {
     pub min_base_order_size: u64,
     /// Enables the limiting of price precision on the orderbook (price ticks)
     pub price_bitmask: u64,
+    /// Fixed fee for every new order operation. A higher fee increases incentives for cranking.
+    pub cranker_reward: u64,
 }
 
 struct Accounts<'a, 'b: 'a> {
@@ -82,6 +84,7 @@ pub(crate) fn process(
         callback_id_len,
         min_base_order_size,
         price_bitmask,
+        cranker_reward,
     } = params;
 
     check_unitialized(accounts.event_queue)?;
@@ -108,6 +111,7 @@ pub(crate) fn process(
         initial_lamports: accounts.market.lamports(),
         min_base_order_size,
         price_bitmask,
+        cranker_reward,
     };
 
     let event_queue_header = EventQueueHeader::initialize(params.callback_info_len as usize);

--- a/program/src/processor/new_order.rs
+++ b/program/src/processor/new_order.rs
@@ -14,7 +14,6 @@ use crate::{
         EventQueue, EventQueueHeader, MarketState, SelfTradeBehavior, Side, EVENT_QUEUE_HEADER_LEN,
     },
     utils::{check_account_key, check_account_owner, check_signer},
-    CRANKER_REWARD,
 };
 
 #[derive(BorshDeserialize, BorshSerialize, Clone)]
@@ -140,7 +139,10 @@ pub(crate) fn process(
     //Verify that fees were transfered. Fees are expected to be transfered by the caller program in order
     // to reduce the CPI call stack depth.
     if accounts.market.lamports() - market_state.initial_lamports
-        < market_state.fee_budget + CRANKER_REWARD
+        < market_state
+            .fee_budget
+            .checked_add(market_state.cranker_reward)
+            .unwrap()
     {
         msg!("Fees were not correctly payed during caller runtime.");
         return Err(AoError::FeeNotPayed.into());

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -89,6 +89,8 @@ pub struct MarketState {
     pub min_base_order_size: u64,
     /// Enables the limiting of price precision on the orderbook (price ticks)
     pub price_bitmask: u64,
+    /// Cranker reward (in lamports)
+    pub cranker_reward: u64,
 }
 
 /// Expected size in bytes of MarketState

--- a/program/tests/common/utils.rs
+++ b/program/tests/common/utils.rs
@@ -94,6 +94,7 @@ pub async fn create_market_and_accounts(
             callback_id_len: 32,
             min_base_order_size: 10,
             price_bitmask: u64::MAX,
+            cranker_reward: 0,
         },
     );
     sign_send_instructions(&mut prg_test_ctx, vec![create_market_instruction], vec![])


### PR DESCRIPTION
This PR allows caller programs to set the fixed fees that would go to crankers. Setting this fee should be done strategically to maximize cranker incentives for particular use cases.

If there is any interest, it could be possible to implement a `change_fees` instruction to enable developers to adapt their fees in production.