### PR TITLE
Implement mass cancel quotes (first pass)

### DIFF
--- a/program/src/critbit.rs
+++ b/program/src/critbit.rs
@@ -719,6 +719,29 @@ impl<'a> Slab<'a> {
         self.remove_by_key(key)
     }
 
+    pub fn inorder_traversal(&self, ascending: bool) -> Vec<LeafNode> {
+        let mut leaves = vec![];
+        let mut stack: Vec<NodeHandle> = vec![];
+        match self.root() {
+            Some(root) => stack.push(root),
+            None => return leaves,
+        }
+        while !stack.is_empty() {
+            let node = stack.pop().unwrap();
+            match self.get_node(node).unwrap() {
+                NodeRef::Leaf(leaf) => {
+                    leaves.push(*leaf);
+                }
+                NodeRef::Inner(inner) => {
+                    stack.push(inner.children[0 ^ ascending as usize]);
+                    stack.push(inner.children[1 ^ ascending as usize]);
+                }
+                _ => unreachable!(),
+            }
+        }
+        return leaves;
+    }
+
     /////////////////////////////////////////
     // Misc
 

--- a/program/src/critbit.rs
+++ b/program/src/critbit.rs
@@ -733,8 +733,8 @@ impl<'a> Slab<'a> {
                     leaves.push(*leaf);
                 }
                 NodeRef::Inner(inner) => {
-                    stack.push(inner.children[0 ^ ascending as usize]);
                     stack.push(inner.children[1 ^ ascending as usize]);
+                    stack.push(inner.children[0 ^ ascending as usize]);
                 }
                 _ => unreachable!(),
             }

--- a/program/src/critbit.rs
+++ b/program/src/critbit.rs
@@ -733,8 +733,8 @@ impl<'a> Slab<'a> {
                     leaves.push(*leaf);
                 }
                 NodeRef::Inner(inner) => {
-                    stack.push(inner.children[1 ^ ascending as usize]);
                     stack.push(inner.children[0 ^ ascending as usize]);
+                    stack.push(inner.children[1 ^ ascending as usize]);
                 }
                 _ => unreachable!(),
             }

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -73,6 +73,9 @@ impl PrintProgramError for AoError {
             AoError::IllegalMsrmOwner => {
                 msg!("Error: Illegal MSRM token account owner")
             }
+            AoError::InvalidCallbackIdLength => {
+                msg!("Callback ID is the incorrect length")
+            }
         }
     }
 }

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -76,6 +76,9 @@ impl PrintProgramError for AoError {
             AoError::InvalidCallbackIdLength => {
                 msg!("Callback ID is the incorrect length")
             }
+            AoError::IntegerOverflow => {
+                msg!("Integer overflow")
+            }
         }
     }
 }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -50,6 +50,8 @@ pub enum AoError {
     WrongMsrmBalance,
     #[error("Illegal MSRM token account owner")]
     IllegalMsrmOwner,
+    #[error("Callback ID is the incorrect length")]
+    InvalidCallbackIdLength,
 }
 
 impl From<AoError> for ProgramError {

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -52,6 +52,8 @@ pub enum AoError {
     IllegalMsrmOwner,
     #[error("Callback ID is the incorrect length")]
     InvalidCallbackIdLength,
+    #[error("Integer overflow")]
+    IntegerOverflow,
 }
 
 impl From<AoError> for ProgramError {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -3,7 +3,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use num_derive::FromPrimitive;
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 
-pub use crate::processor::{cancel_order, close_market, consume_events, create_market, new_order};
+pub use crate::processor::{
+    cancel_order, close_market, consume_events, create_market, mass_cancel_quotes, new_order,
+};
 #[derive(BorshDeserialize, BorshSerialize, FromPrimitive)]
 /// Describes all possible instructions and their required accounts
 pub enum AgnosticOrderbookInstruction {
@@ -70,6 +72,18 @@ pub enum AgnosticOrderbookInstruction {
     /// | 4     | ❌        | ✅      | The caller authority        |
     /// | 5     | ✅        | ❌      | The lamports target account |
     CloseMarket,
+    /// Cancels the most aggressive quotes in the book based on a callback identifier
+    ///
+    /// Required accounts
+    ///
+    /// | index | writable | signer | description             |
+    /// |-------|----------|--------|-------------------------|
+    /// | 0     | ✅       | ❌     | The market account      |
+    /// | 1     | ✅       | ❌     | The event queue account |
+    /// | 2     | ✅       | ❌     | The bids account        |
+    /// | 3     | ✅       | ❌     | The asks account        |
+    /// | 4     | ❌       | ✅     | The caller authority    |
+    MassCancelQuotes,
 }
 
 /**
@@ -151,6 +165,19 @@ pub fn close_market(
     accounts.get_instruction(
         program_id,
         AgnosticOrderbookInstruction::CloseMarket as u8,
+        params,
+    )
+}
+
+/// Cancel multiple orders from the book
+pub fn mass_cancel_quotes(
+    program_id: Pubkey,
+    accounts: mass_cancel_quotes::Accounts<Pubkey>,
+    params: mass_cancel_quotes::Params,
+) -> Instruction {
+    accounts.get_instruction(
+        program_id,
+        AgnosticOrderbookInstruction::MassCancelQuotes as u8,
         params,
     )
 }

--- a/program/src/orderbook.rs
+++ b/program/src/orderbook.rs
@@ -345,10 +345,10 @@ impl<'ob> OrderBookState<'ob> {
                         .map_err(|_| AoError::EventQueueFull)?;
                     total_base_qty = total_base_qty
                         .checked_add(leaf.base_quantity)
-                        .ok_or(|_| AoError::IntegerOverflow)?;
+                        .ok_or_else(|| AoError::IntegerOverflow)?;
                     total_quote_qty = total_quote_qty
                         .checked_add(fp32_mul(leaf.base_quantity, leaf.price()))
-                        .ok_or(|_| AoError::IntegerOverflow)?;
+                        .ok_or_else(|| AoError::IntegerOverflow)?;
                     num_orders_cancelled += 1
                 }
                 if num_orders_cancelled == params.num_orders {

--- a/program/src/orderbook.rs
+++ b/program/src/orderbook.rs
@@ -330,7 +330,7 @@ impl<'ob> OrderBookState<'ob> {
                     .all(|(a, b)| a == b)
                 {
                     let order_id = leaf.order_id();
-                    book.remove_by_key(order_id);
+                    book.remove_by_key(order_id).ok_or(AoError::OrderNotFound)?;
                     let cancel = Event::Out {
                         side: get_side_from_order_id(order_id),
                         delete: true,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -11,6 +11,7 @@ pub mod cancel_order;
 pub mod close_market;
 pub mod consume_events;
 pub mod create_market;
+pub mod mass_cancel_quotes;
 pub mod new_order;
 
 #[allow(missing_docs)]
@@ -67,6 +68,13 @@ impl Processor {
                 msg!("Instruction: Close Market");
                 let accounts = close_market::Accounts::parse(accounts)?;
                 close_market::process(program_id, accounts, close_market::Params {})?;
+            }
+            AgnosticOrderbookInstruction::MassCancelQuotes => {
+                msg!("Instruction: Mass Cancel Quotes");
+                let accounts = mass_cancel_quotes::Accounts::parse(accounts)?;
+                let params = mass_cancel_quotes::Params::try_from_slice(instruction_data)
+                    .map_err(|_| ProgramError::InvalidInstructionData)?;
+                mass_cancel_quotes::process(program_id, accounts, params)?;
             }
         }
         Ok(())

--- a/program/src/processor/mass_cancel_quotes.rs
+++ b/program/src/processor/mass_cancel_quotes.rs
@@ -25,7 +25,7 @@ pub struct Params {
     pub callback_id: Vec<u8>,
 }
 
-/// The required accounts for a cancel_order instruction.
+/// The required accounts for a mass_cancel_quotes instruction.
 #[derive(InstructionsAccount)]
 pub struct Accounts<'a, T> {
     #[allow(missing_docs)]

--- a/program/src/processor/mass_cancel_quotes.rs
+++ b/program/src/processor/mass_cancel_quotes.rs
@@ -1,0 +1,143 @@
+//! Cancels the most aggressive quotes in the book based on a callback identifier
+
+use bonfida_utils::{BorshSize, InstructionsAccount};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+use crate::{
+    error::AoError,
+    orderbook::OrderBookState,
+    state::{EventQueue, EventQueueHeader, MarketState, Side, EVENT_QUEUE_HEADER_LEN},
+    utils::{assert, check_account_key, check_account_owner, check_signer},
+};
+#[derive(BorshDeserialize, BorshSerialize, Clone, BorshSize)]
+/**
+The required arguments for a mass_cancel_quotes instruction.
+*/
+pub struct Params {
+    pub num_orders: u64,
+    pub prioritized_side: Side,
+    pub callback_id: Vec<u8>,
+}
+
+/// The required accounts for a cancel_order instruction.
+#[derive(InstructionsAccount)]
+pub struct Accounts<'a, T> {
+    #[allow(missing_docs)]
+    #[cons(writable)]
+    pub market: &'a T,
+    #[allow(missing_docs)]
+    #[cons(writable)]
+    pub event_queue: &'a T,
+    #[allow(missing_docs)]
+    #[cons(writable)]
+    pub bids: &'a T,
+    #[allow(missing_docs)]
+    #[cons(writable)]
+    pub asks: &'a T,
+    #[allow(missing_docs)]
+    #[cons(signer)]
+    pub authority: &'a T,
+}
+
+impl<'a, 'b: 'a> Accounts<'a, AccountInfo<'b>> {
+    pub(crate) fn parse(accounts: &'a [AccountInfo<'b>]) -> Result<Self, ProgramError> {
+        let accounts_iter = &mut accounts.iter();
+
+        let a = Self {
+            market: next_account_info(accounts_iter)?,
+            event_queue: next_account_info(accounts_iter)?,
+            bids: next_account_info(accounts_iter)?,
+            asks: next_account_info(accounts_iter)?,
+            authority: next_account_info(accounts_iter)?,
+        };
+        Ok(a)
+    }
+
+    /// Perform basic security checks on the accounts
+    pub(crate) fn perform_checks(&self, program_id: &Pubkey) -> Result<(), ProgramError> {
+        check_account_owner(
+            self.market,
+            &program_id.to_bytes(),
+            AoError::WrongMarketOwner,
+        )?;
+        check_account_owner(
+            self.event_queue,
+            &program_id.to_bytes(),
+            AoError::WrongEventQueueOwner,
+        )?;
+        check_account_owner(self.bids, &program_id.to_bytes(), AoError::WrongBidsOwner)?;
+        check_account_owner(self.asks, &program_id.to_bytes(), AoError::WrongAsksOwner)?;
+        #[cfg(not(feature = "lib"))]
+        check_signer(self.authority)?;
+        Ok(())
+    }
+}
+/// Apply the mass_cancel_quotes instruction to the provided accounts
+pub fn process<'a, 'b: 'a>(
+    program_id: &Pubkey,
+    accounts: Accounts<'a, AccountInfo<'b>>,
+    params: Params,
+) -> ProgramResult {
+    accounts.perform_checks(program_id)?;
+    let market_state = MarketState::get(accounts.market)?;
+
+    check_accounts_and_params(&accounts, &params, &market_state)?;
+
+    let callback_info_len = market_state.callback_info_len as usize;
+
+    let mut order_book = OrderBookState::new_safe(
+        accounts.bids,
+        accounts.asks,
+        market_state.callback_info_len as usize,
+        market_state.callback_id_len as usize,
+    )?;
+
+    let header = {
+        let mut event_queue_data: &[u8] =
+            &accounts.event_queue.data.borrow()[0..EVENT_QUEUE_HEADER_LEN];
+        EventQueueHeader::deserialize(&mut event_queue_data).unwrap()
+    };
+    let mut event_queue = EventQueue::new_safe(header, accounts.event_queue, callback_info_len)?;
+
+    order_book.mass_cancel(&params, &mut event_queue)?;
+    let mut event_queue_header_data: &mut [u8] = &mut accounts.event_queue.data.borrow_mut();
+    event_queue
+        .header
+        .serialize(&mut event_queue_header_data)
+        .unwrap();
+    order_book.commit_changes();
+
+    Ok(())
+}
+
+fn check_accounts_and_params<'a, 'b: 'a>(
+    accounts: &Accounts<'a, AccountInfo<'b>>,
+    params: &Params,
+    market_state: &MarketState,
+) -> ProgramResult {
+    assert(
+        market_state.callback_id_len as usize == params.callback_id.len(),
+        AoError::InvalidCallbackIdLength,
+    )?;
+    check_account_key(
+        accounts.event_queue,
+        &market_state.event_queue,
+        AoError::WrongEventQueueAccount,
+    )?;
+    check_account_key(accounts.bids, &market_state.bids, AoError::WrongBidsAccount)?;
+    check_account_key(accounts.asks, &market_state.asks, AoError::WrongAsksAccount)?;
+    #[cfg(not(feature = "lib"))]
+    check_account_key(
+        accounts.authority,
+        &market_state.caller_authority,
+        AoError::WrongCallerAuthority,
+    )?;
+
+    Ok(())
+}

--- a/program/src/processor/mass_cancel_quotes.rs
+++ b/program/src/processor/mass_cancel_quotes.rs
@@ -22,7 +22,7 @@ The required arguments for a mass_cancel_quotes instruction.
 */
 pub struct Params {
     pub num_orders: u64,
-    pub prioritized_side: Side,
+    pub side: Side,
     pub callback_id: Vec<u8>,
 }
 

--- a/program/src/processor/mass_cancel_quotes.rs
+++ b/program/src/processor/mass_cancel_quotes.rs
@@ -5,6 +5,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint::ProgramResult,
+    msg,
     program_error::ProgramError,
     pubkey::Pubkey,
 };
@@ -105,7 +106,9 @@ pub fn process<'a, 'b: 'a>(
     };
     let mut event_queue = EventQueue::new_safe(header, accounts.event_queue, callback_info_len)?;
 
-    order_book.mass_cancel(&params, &mut event_queue)?;
+    let order_summary = order_book.mass_cancel(&params, &mut event_queue)?;
+    msg!("Order summary : {:?}", order_summary);
+    event_queue.write_to_register(order_summary);
     let mut event_queue_header_data: &mut [u8] = &mut accounts.event_queue.data.borrow_mut();
     event_queue
         .header

--- a/program/src/utils.rs
+++ b/program/src/utils.rs
@@ -18,6 +18,14 @@ unsafe fn invariant(check: bool) {
     }
 }
 
+pub fn assert(statement: bool, err: AoError) -> Result<(), AoError> {
+    if !statement {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
 // Safety verification functions
 pub fn check_account_key(account: &AccountInfo, key: &[u8], error: AoError) -> Result<(), AoError> {
     if account.key.to_bytes() != key {

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -322,8 +322,8 @@ async fn test_agnostic_orderbook() {
         },
         new_order::Params {
             max_base_qty: 1100,
-            max_quote_qty: 1000,
-            limit_price: 1000,
+            max_quote_qty: u64::max_value(),
+            limit_price: 100 << 32,
             side: Side::Ask,
             callback_info: trader.to_bytes().to_vec(),
             post_only: false,
@@ -352,8 +352,8 @@ async fn test_agnostic_orderbook() {
         },
         new_order::Params {
             max_base_qty: 1100,
-            max_quote_qty: 1000,
-            limit_price: 1001,
+            max_quote_qty: u64::max_value(),
+            limit_price: 101 << 32,
             side: Side::Ask,
             callback_info: trader.to_bytes().to_vec(),
             post_only: false,
@@ -383,8 +383,8 @@ async fn test_agnostic_orderbook() {
         },
         new_order::Params {
             max_base_qty: 1100,
-            max_quote_qty: 1000,
-            limit_price: 1001,
+            max_quote_qty: u64::max_value(),
+            limit_price: 101 << 32,
             side: Side::Ask,
             callback_info: trader_2.to_bytes().to_vec(),
             post_only: false,

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -413,7 +413,7 @@ async fn test_agnostic_orderbook() {
         },
         mass_cancel_quotes::Params {
             num_orders: 10,
-            prioritized_side: Side::Bid,
+            side: Side::Ask,
             callback_id: trader.to_bytes().to_vec(),
         },
     );
@@ -437,7 +437,7 @@ async fn test_agnostic_orderbook() {
         },
         mass_cancel_quotes::Params {
             num_orders: 10,
-            prioritized_side: Side::Bid,
+            side: Side::Ask,
             callback_id: trader_2.to_bytes().to_vec(),
         },
     );


### PR DESCRIPTION
Here is an initial implementation of a mass cancel instruction. It's by no means rigorously tested yet, but I did add to the test file to test basic functionality. Note that if you remove either of the `mass_cancel` calls, the test will fail.

I don't know what the team's conventions are regarding style, but open to any and all feedback.