### PR TITLE
Allow the creation of event queues of sizes != 79 + event_size * N without index errors

### DIFF
--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(map_first_last)]
 #![warn(missing_docs)]
 /*!
 Orderbook program which can be used with generic assets.

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(map_first_last)]
 #![warn(missing_docs)]
 /*!
 Orderbook program which can be used with generic assets.

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -11,7 +11,7 @@ use solana_program::{
 use crate::{
     critbit::Slab,
     error::AoError,
-    state::{AccountTag, EventQueueHeader, MarketState},
+    state::{AccountTag, EventQueueHeader, EventQueue, MarketState},
     utils::{check_account_owner, check_unitialized},
 };
 
@@ -102,6 +102,7 @@ pub fn process<'a, 'b: 'a>(
     check_unitialized(accounts.bids)?;
     check_unitialized(accounts.asks)?;
     check_unitialized(accounts.market)?;
+    EventQueue::check_buffer_size(accounts.event_queue, params.callback_info_len)?;
 
     let mut market_state = MarketState::get_unchecked(accounts.market);
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -335,7 +335,9 @@ impl<'a> EventQueue<'a> {
     }
 
     pub(crate) fn get_buf_len(&self) -> usize {
-        self.buffer.borrow().len() - EVENT_QUEUE_HEADER_LEN - (REGISTER_SIZE)
+        let buffer_len = self.buffer.borrow().len() - EVENT_QUEUE_HEADER_LEN - REGISTER_SIZE;
+        let remainder = buffer_len % self.header.event_size as usize;
+        buffer_len - remainder
     }
 
     pub(crate) fn full(&self) -> bool {

--- a/program/tests/common/utils.rs
+++ b/program/tests/common/utils.rs
@@ -1,4 +1,5 @@
 use agnostic_orderbook::instruction::create_market;
+use agnostic_orderbook::state::Event;
 use solana_program::instruction::Instruction;
 use solana_program::pubkey::Pubkey;
 use solana_program::system_instruction::create_account;
@@ -36,7 +37,7 @@ pub async fn create_market_and_accounts(
         &prg_test_ctx.payer.pubkey(),
         &event_queue_account.pubkey(),
         1_000_000,
-        1_000_000,
+        (79 + (Event::compute_slot_size(32) * 10000)) as u64,
         &agnostic_orderbook_program_id,
     );
     sign_send_instructions(

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -101,23 +101,6 @@ async fn test_agnostic_orderbook() {
     .await
     .unwrap();
 
-    // Create event queue account
-    let event_queue_account = Keypair::new();
-    let create_event_queue_account_instruction = create_account(
-        &prg_test_ctx.payer.pubkey(),
-        &event_queue_account.pubkey(),
-        1_000_000,
-        1_000_000,
-        &agnostic_orderbook::ID,
-    );
-    sign_send_instructions(
-        &mut prg_test_ctx,
-        vec![create_event_queue_account_instruction],
-        vec![&event_queue_account],
-    )
-    .await
-    .unwrap();
-
     let caller_authority = Keypair::new();
     let market_account =
         create_market_and_accounts(&mut prg_test_ctx, agnostic_orderbook::ID, &caller_authority)


### PR DESCRIPTION
There was previously an index OOB bug if the event queue is initially allocated to an invalid size. This change makes it so the buffer (minus header + register) will size down to a multiple of the event size.

Obviously you can just always allocate the event queue to `79 + event_size * N` for a capacity of `N` events, but this is safer