### PR TITLE
Fix matching bug when price < 1

### DIFF
--- a/program/src/orderbook.rs
+++ b/program/src/orderbook.rs
@@ -257,7 +257,7 @@ impl<'ob> OrderBookState<'ob> {
             base_qty_remaining,
         );
 
-        if crossed || !post_allowed || base_qty_to_post <= min_base_order_size {
+        if crossed || !post_allowed || base_qty_to_post < min_base_order_size {
             return Ok(OrderSummary {
                 posted_order_id: None,
                 total_base_qty: max_base_qty - base_qty_remaining,

--- a/program/src/orderbook.rs
+++ b/program/src/orderbook.rs
@@ -148,6 +148,12 @@ impl<'ob> OrderBookState<'ob> {
                 break;
             }
 
+            let quote_maker_qty = fp32_mul(base_trade_qty, trade_price);
+
+            if quote_maker_qty == 0 {
+                break;
+            }
+
             // The decrement take case can be handled by the caller program on event consumption, so no special logic
             // is needed for it.
             if self_trade_behavior != SelfTradeBehavior::DecrementTake {
@@ -198,8 +204,6 @@ impl<'ob> OrderBookState<'ob> {
                     continue;
                 }
             }
-
-            let quote_maker_qty = fp32_mul(base_trade_qty, trade_price);
 
             let maker_fill = Event::Fill {
                 taker_side: side,


### PR DESCRIPTION
This PR aims to fix a reported bug which happens when matching a seller order with a price < 1. This results in an "infinite" (bounded by match limit) loop of zero-quote non-zero-base fill events.