### PR TITLE
Add into_iter method for Slab

### DIFF
--- a/program/src/critbit.rs
+++ b/program/src/critbit.rs
@@ -949,8 +949,8 @@ impl<'slab> Slab<'slab> {
     /// Get a price ascending or price descending iterator over all the Slab's orders
     pub fn into_iter(self, price_ascending: bool) -> impl Iterator<Item = LeafNode> + 'slab {
         SlabIterator {
+            search_stack: self.root().iter().copied().collect(),
             slab: self,
-            search_stack: Vec::new(),
             ascending: price_ascending,
         }
     }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -50,7 +50,7 @@ pub mod instruction;
 /// Describes the different data structres that the program uses to encode state
 pub mod state;
 
-#[doc(hidden)]
+/// Describes the orderbook's underlying data structure, the [`Slab`].
 pub mod critbit;
 #[doc(hidden)]
 pub mod error;


### PR DESCRIPTION
This PR adds an iterator over all open orders for the critbit Slab. The `into_iter` method can be used to generate price ascending or descending iterators.

This PR implements a feature request formulated in issue #30.