### PR TITLE
Fix callback info corruption on order booting

### DIFF
--- a/program/src/orderbook.rs
+++ b/program/src/orderbook.rs
@@ -280,7 +280,7 @@ impl<'ob> OrderBookState<'ob> {
         if let Err(AoError::SlabOutOfSpace) = insert_result {
             // Boot out the least aggressive orders
             msg!("Orderbook is full! booting lest aggressive orders...");
-            let order = match side {
+            let (order, callback_info) = match side {
                 Side::Bid => self.get_tree(Side::Bid).remove_min().unwrap(),
                 Side::Ask => self.get_tree(Side::Ask).remove_max().unwrap(),
             };
@@ -290,10 +290,7 @@ impl<'ob> OrderBookState<'ob> {
                 delete: true,
                 order_id: l.order_id(),
                 base_size: l.base_quantity,
-                callback_info: self
-                    .get_tree(side)
-                    .get_callback_info(l.callback_info_pt as usize)
-                    .to_owned(),
+                callback_info,
             };
             event_queue
                 .push_back(out)

--- a/program/src/processor/cancel_order.rs
+++ b/program/src/processor/cancel_order.rs
@@ -109,7 +109,7 @@ pub fn process<'a, 'b: 'a>(
     let event_queue = EventQueue::new_safe(header, accounts.event_queue, callback_info_len)?;
 
     let slab = order_book.get_tree(get_side_from_order_id(params.order_id));
-    let node = slab
+    let (node, _) = slab
         .remove_by_key(params.order_id)
         .ok_or(AoError::OrderNotFound)?;
     let leaf_node = node.as_leaf().unwrap();

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -385,9 +385,7 @@ impl<'a> EventQueue<'a> {
         let offset = ((self
             .header
             .head
-            .checked_add(index)
-            .unwrap()
-            .checked_mul(self.header.event_size)
+            .checked_add(index.checked_mul(self.header.event_size).unwrap())
             .unwrap()) as usize
             % self.get_buf_len())
             + header_offset;


### PR DESCRIPTION
This PR fixes an issue which arises when orders get booted from an overfull orderbook : their callback information is partially erased / corrupted before it can be reported in an `Out` event.