### PR TITLE
program: caller program must round `limit_price` to nearest `tick_size`

### DIFF
--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -73,6 +73,9 @@ impl PrintProgramError for AoError {
             AoError::IllegalMsrmOwner => {
                 msg!("Error: Illegal MSRM token account owner")
             }
+            AoError::InvalidLimitPrice => {
+                msg!("Error: Limit price must be a tick size multiple")
+            }
         }
     }
 }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -50,6 +50,8 @@ pub enum AoError {
     WrongMsrmBalance,
     #[error("Illegal MSRM token account owner")]
     IllegalMsrmOwner,
+    #[error("Limit price must be a tick size multiple")]
+    InvalidLimitPrice,
 }
 
 impl From<AoError> for ProgramError {


### PR DESCRIPTION
This PR forces caller programs to round the `limit_price` to the nearest `tick_size` instead of rounding the price on the AOB side in order to prevent price discrepancies between the two.

Rounding can be made using `crate::utils::round_price`