### PR TITLE
Rearrange struct for aarch64/M1 compatibility

### DIFF
--- a/js/src/slab.ts
+++ b/js/src/slab.ts
@@ -21,8 +21,8 @@ export class InnerNode {
       {
         kind: "struct",
         fields: [
-          ["prefixLen", "u64"],
           ["key", "u128"],
+          ["prefixLen", "u64"],
           ["children", ["u32", 2]],
         ],
       },

--- a/program/src/critbit.rs
+++ b/program/src/critbit.rs
@@ -24,8 +24,8 @@ pub type IoError = std::io::Error;
 #[derive(BorshDeserialize, BorshSerialize, Debug, PartialEq, Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct InnerNode {
-    prefix_len: u64,
     key: u128,
+    prefix_len: u64,
     pub children: [u32; 2],
 }
 

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -11,7 +11,7 @@ use solana_program::{
 use crate::{
     critbit::Slab,
     error::AoError,
-    state::{AccountTag, EventQueueHeader, EventQueue, MarketState},
+    state::{AccountTag, EventQueue, EventQueueHeader, MarketState},
     utils::{check_account_owner, check_unitialized},
 };
 


### PR DESCRIPTION
This PR attempts to make the AOB data structures compatible with the aarch64 / Apple M1 alignment requirements.