### PR TITLE
Fix quote_qty overflow when supplier quote_qty is too large.

### DIFF
--- a/program/src/state/orderbook.rs
+++ b/program/src/state/orderbook.rs
@@ -161,10 +161,9 @@ where
             }
 
             let offer_size = best_bo_ref.base_quantity;
-            let base_trade_qty = offer_size.min(base_qty_remaining).min(
-                fp32_div(quote_qty_remaining, best_bo_ref.price())
-                    .ok_or(AoError::NumericalOverflow)?,
-            );
+            let base_trade_qty = offer_size
+                .min(base_qty_remaining)
+                .min(fp32_div(quote_qty_remaining, best_bo_ref.price()).unwrap_or(u64::MAX));
 
             if base_trade_qty == 0 {
                 break;


### PR DESCRIPTION
This PR aims to solve a bug which prevents users from specifying an arbitrarily large `max_quote_qty` in a `new_order` instruction, whereas supporting this is an important part of the API spec.