### PR TITLE
Allow for pausing orderbook matching

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -7,6 +7,7 @@ use solana_program::{
 
 use bonfida_utils::{BorshSize, InstructionsAccount};
 
+use crate::processor::pause_matching;
 pub use crate::processor::{
     cancel_order, close_market, consume_events, create_market, mass_cancel_orders, new_order,
 };
@@ -88,6 +89,14 @@ pub enum AgnosticOrderbookInstruction {
     /// | 3     | ✅       | ❌     | The asks account        |
     /// | 4     | ❌       | ✅     | The caller authority    |
     MassCancelOrders,
+    /// Pause the matching engine.
+    ///
+    /// Required accounts
+    ///
+    /// | index | writable | signer   | description                 |
+    /// |-------|----------|----------|-----------------------------|
+    /// | 0     | ✅        | ❌      | The market account          |
+    PauseMatching,
 }
 
 /**
@@ -218,6 +227,26 @@ pub fn mass_cancel_orders(
         AgnosticOrderbookInstruction::CloseMarket as u8,
         params,
     );
+    i.accounts.push(AccountMeta {
+        pubkey: register_account,
+        is_signer: false,
+        is_writable: true,
+    });
+    i
+}
+
+/// Pause the matching engine.
+pub fn pause_matching(
+    accounts: pause_matching::Accounts<Pubkey>,
+    register_account: Pubkey,
+    params: close_market::Params,
+) -> Instruction {
+    let mut i = accounts.get_instruction(
+        crate::id(),
+        AgnosticOrderbookInstruction::PauseMatching as u8,
+        params,
+    );
+
     i.accounts.push(AccountMeta {
         pubkey: register_account,
         is_signer: false,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -16,6 +16,7 @@ pub mod create_market;
 pub mod mass_cancel_orders;
 pub mod new_order;
 pub mod pause_matching;
+pub mod resume_matching;
 
 pub fn process_instruction<C: Pod + BorshDeserialize + CallbackInfo + PartialEq>(
     program_id: &Pubkey,
@@ -76,6 +77,11 @@ where
             msg!("Instruction: Pause Matching");
             let accounts = pause_matching::Accounts::parse(accounts)?;
             pause_matching::process::<C>(program_id, accounts, pause_matching::Params {})?;
+        }
+        AgnosticOrderbookInstruction::ResumeMatching => {
+            msg!("Instruction: Resume Matching");
+            let accounts = resume_matching::Accounts::parse(accounts)?;
+            resume_matching::process::<C>(program_id, accounts, resume_matching::Params {})?;
         }
     }
     Ok(None)

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -15,6 +15,7 @@ pub mod consume_events;
 pub mod create_market;
 pub mod mass_cancel_orders;
 pub mod new_order;
+pub mod pause_matching;
 
 pub fn process_instruction<C: Pod + BorshDeserialize + CallbackInfo + PartialEq>(
     program_id: &Pubkey,
@@ -70,6 +71,11 @@ where
             let params = mass_cancel_orders::Params::try_from_slice(instruction_data)
                 .map_err(|_| ProgramError::InvalidInstructionData)?;
             return mass_cancel_orders::process::<C>(program_id, accounts, params).map(Some);
+        }
+        AgnosticOrderbookInstruction::PauseMatching => {
+            msg!("Instruction: Pause Matching");
+            let accounts = pause_matching::Accounts::parse(accounts)?;
+            pause_matching::process::<C>(program_id, accounts, pause_matching::Params {})?;
         }
     }
     Ok(None)

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -96,13 +96,13 @@ pub fn process<'a, 'b: 'a, C: Pod>(
 
     let market_state = MarketState::from_buffer(&mut market_data, AccountTag::Uninitialized)?;
 
-    *market_state = MarketState {
-        event_queue: *accounts.event_queue.key,
-        bids: *accounts.bids.key,
-        asks: *accounts.asks.key,
+    *market_state = MarketState::init_new(
+        accounts.event_queue.key,
+        accounts.bids.key,
+        accounts.asks.key,
         min_base_order_size,
         tick_size,
-    };
+    );
 
     let mut event_queue_data = accounts.event_queue.data.borrow_mut();
 

--- a/program/src/processor/new_order.rs
+++ b/program/src/processor/new_order.rs
@@ -141,8 +141,15 @@ where
     let mut event_queue_guard = accounts.event_queue.data.borrow_mut();
     let mut event_queue = EventQueue::from_buffer(&mut event_queue_guard, AccountTag::EventQueue)?;
 
-    let order_summary =
-        order_book.new_order(params, &mut event_queue, market_state.min_base_order_size)?;
+    let order_summary = match market_state.pause_matching {
+        0 => order_book.new_order(params, &mut event_queue, market_state.min_base_order_size)?,
+        1 => order_book.insert_without_matching(
+            params,
+            &mut event_queue,
+            market_state.min_base_order_size,
+        )?,
+        _ => panic!("unreachable"),
+    };
     msg!("Order summary : {:?}", order_summary);
 
     Ok(order_summary)

--- a/program/src/processor/pause_matching.rs
+++ b/program/src/processor/pause_matching.rs
@@ -1,0 +1,67 @@
+//! Close an existing market.
+use crate::{
+    error::AoError,
+    state::{market_state::MarketState, orderbook::CallbackInfo, AccountTag},
+    utils::check_account_owner,
+};
+use bonfida_utils::{BorshSize, InstructionsAccount};
+use borsh::{BorshDeserialize, BorshSerialize};
+use bytemuck::Pod;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+#[derive(BorshDeserialize, BorshSerialize, BorshSize)]
+/**
+The required arguments for a close_market instruction.
+*/
+pub struct Params {}
+
+/// The required accounts for a close_market instruction.
+#[derive(InstructionsAccount)]
+pub struct Accounts<'a, T> {
+    #[allow(missing_docs)]
+    #[cons(writable)]
+    pub market: &'a T,
+}
+
+impl<'a, 'b: 'a> Accounts<'a, AccountInfo<'b>> {
+    pub(crate) fn parse(accounts: &'a [AccountInfo<'b>]) -> Result<Self, ProgramError> {
+        let accounts_iter = &mut accounts.iter();
+
+        let a = Self {
+            market: next_account_info(accounts_iter)?,
+        };
+        Ok(a)
+    }
+
+    pub(crate) fn perform_checks(&self, program_id: &Pubkey) -> Result<(), ProgramError> {
+        check_account_owner(
+            self.market,
+            &program_id.to_bytes(),
+            AoError::WrongMarketOwner,
+        )?;
+        Ok(())
+    }
+}
+/// Apply the close_market instruction to the provided accounts
+pub fn process<'a, 'b: 'a, C: CallbackInfo + PartialEq + Pod>(
+    program_id: &Pubkey,
+    accounts: Accounts<'a, AccountInfo<'b>>,
+    _params: Params,
+) -> ProgramResult
+where
+    <C as CallbackInfo>::CallbackId: PartialEq,
+{
+    accounts.perform_checks(program_id)?;
+    let mut market_data = accounts.market.data.borrow_mut();
+    let market_state = MarketState::from_buffer(&mut market_data, AccountTag::Market)?;
+
+    // bytemuck does not like boolean values
+    market_state.pause_matching = 1;
+
+    Ok(())
+}

--- a/program/src/processor/resume_matching.rs
+++ b/program/src/processor/resume_matching.rs
@@ -1,0 +1,121 @@
+//! Execute a new order on the orderbook
+
+use bonfida_utils::{BorshSize, InstructionsAccount};
+use borsh::{BorshDeserialize, BorshSerialize};
+use bytemuck::Pod;
+use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint::ProgramResult,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+};
+
+use crate::{
+    error::AoError,
+    state::{
+        event_queue::EventQueue,
+        market_state::MarketState,
+        orderbook::{CallbackInfo, OrderBookState},
+        AccountTag,
+    },
+    utils::{check_account_key, check_account_owner},
+};
+
+#[derive(BorshDeserialize, BorshSerialize, BorshSize)]
+/**
+The required arguments for a new_order instruction.
+*/
+pub struct Params {}
+
+/// The required accounts for a new_order instruction.
+#[derive(InstructionsAccount)]
+pub struct Accounts<'a, T> {
+    #[allow(missing_docs)]
+    pub market: &'a T,
+    #[allow(missing_docs)]
+    #[cons(writable)]
+    pub event_queue: &'a T,
+    #[allow(missing_docs)]
+    #[cons(writable)]
+    pub bids: &'a T,
+    #[allow(missing_docs)]
+    #[cons(writable)]
+    pub asks: &'a T,
+}
+
+impl<'a, 'b: 'a> Accounts<'a, AccountInfo<'b>> {
+    pub(crate) fn parse(accounts: &'a [AccountInfo<'b>]) -> Result<Self, ProgramError> {
+        let accounts_iter = &mut accounts.iter();
+
+        let a = Self {
+            market: next_account_info(accounts_iter)?,
+            event_queue: next_account_info(accounts_iter)?,
+            bids: next_account_info(accounts_iter)?,
+            asks: next_account_info(accounts_iter)?,
+        };
+        Ok(a)
+    }
+    pub(crate) fn perform_checks(&self, program_id: &Pubkey) -> Result<(), ProgramError> {
+        check_account_owner(
+            self.market,
+            &program_id.to_bytes(),
+            AoError::WrongMarketOwner,
+        )?;
+        check_account_owner(
+            self.event_queue,
+            &program_id.to_bytes(),
+            AoError::WrongEventQueueOwner,
+        )?;
+        check_account_owner(self.bids, &program_id.to_bytes(), AoError::WrongBidsOwner)?;
+        check_account_owner(self.asks, &program_id.to_bytes(), AoError::WrongAsksOwner)?;
+        Ok(())
+    }
+}
+
+/// Apply the new_order instruction to the provided accounts
+pub fn process<'a, 'b: 'a, C: Pod + CallbackInfo + PartialEq>(
+    program_id: &Pubkey,
+    accounts: Accounts<'a, AccountInfo<'b>>,
+    _params: Params,
+) -> ProgramResult
+where
+    <C as CallbackInfo>::CallbackId: PartialEq,
+{
+    accounts.perform_checks(program_id)?;
+    let mut market_data = accounts.market.data.borrow_mut();
+    let market_state = MarketState::from_buffer(&mut market_data, AccountTag::Market)?;
+
+    check_accounts(&accounts, market_state)?;
+
+    let mut bids_guard = accounts.bids.data.borrow_mut();
+    let mut asks_guard = accounts.asks.data.borrow_mut();
+
+    let mut order_book = OrderBookState::<C>::new_safe(&mut bids_guard, &mut asks_guard)?;
+
+    let mut event_queue_guard = accounts.event_queue.data.borrow_mut();
+    let mut event_queue =
+        EventQueue::<C>::from_buffer(&mut event_queue_guard, AccountTag::EventQueue)?;
+
+    match order_book.match_existing_orders(&mut event_queue, market_state.min_base_order_size) {
+        Ok(_) => {
+            market_state.pause_matching = 1;
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn check_accounts<'a, 'b: 'a>(
+    accounts: &Accounts<'a, AccountInfo<'b>>,
+    market_state: &MarketState,
+) -> ProgramResult {
+    check_account_key(
+        accounts.event_queue,
+        &market_state.event_queue,
+        AoError::WrongEventQueueAccount,
+    )?;
+    check_account_key(accounts.bids, &market_state.bids, AoError::WrongBidsAccount)?;
+    check_account_key(accounts.asks, &market_state.asks, AoError::WrongAsksAccount)?;
+
+    Ok(())
+}

--- a/program/src/state/market_state.rs
+++ b/program/src/state/market_state.rs
@@ -24,11 +24,33 @@ pub struct MarketState {
     pub min_base_order_size: u64,
     /// Tick size (FP32)
     pub tick_size: u64,
+    /// When set to '1' orders will remain on their respective slabs without matching
+    pub pause_matching: u8,
+    _padding: [u8; 7],
 }
 
 impl MarketState {
     /// Expected size in bytes of MarketState
     pub const LEN: usize = size_of::<Self>();
+    #[allow(missing_docs)]
+    pub fn init_new(
+        event_queue: &Pubkey,
+        bids: &Pubkey,
+        asks: &Pubkey,
+        min_base_order_size: u64,
+        tick_size: u64,
+    ) -> Self {
+        Self {
+            event_queue: *event_queue,
+            bids: *bids,
+            asks: *asks,
+            min_base_order_size,
+            tick_size,
+            pause_matching: 0,
+            _padding: [0u8; 7],
+        }
+    }
+
     #[allow(missing_docs)]
     pub fn from_buffer(
         account_data: &mut [u8],

--- a/program/src/state/orderbook.rs
+++ b/program/src/state/orderbook.rs
@@ -321,6 +321,90 @@ where
             total_base_qty_posted: base_qty_to_post,
         })
     }
+
+    pub fn insert_without_matching(
+        &mut self,
+        params: new_order::Params<C>,
+        event_queue: &mut EventQueue<'a, C>,
+        min_base_order_size: u64,
+    ) -> Result<OrderSummary, AoError> {
+        let new_order::Params {
+            max_base_qty,
+            max_quote_qty,
+            side,
+            limit_price,
+            callback_info,
+            post_allowed,
+            ..
+        } = params;
+
+        let base_qty_to_post = std::cmp::min(
+            fp32_div(max_quote_qty, limit_price).unwrap_or(u64::MAX),
+            max_base_qty,
+        );
+
+        if base_qty_to_post < min_base_order_size || !post_allowed {
+            return Ok(OrderSummary {
+                posted_order_id: None,
+                total_base_qty: max_base_qty,
+                total_quote_qty: max_quote_qty,
+                total_base_qty_posted: base_qty_to_post,
+            });
+        }
+
+        let new_leaf_order_id = event_queue.gen_order_id(limit_price, side);
+        let new_leaf = LeafNode {
+            key: new_leaf_order_id,
+            base_quantity: base_qty_to_post,
+        };
+        let insert_result = self.get_tree(side).insert_leaf(&new_leaf);
+        let k = if let Err(AoError::SlabOutOfSpace) = insert_result {
+            // Boot out the least aggressive orders
+            msg!("Orderbook is full! booting least aggressive orders...");
+            let slab = self.get_tree(side);
+            let boot_candidate = match side {
+                Side::Bid => slab.find_min().unwrap(),
+                Side::Ask => slab.find_max().unwrap(),
+            };
+            let boot_candidate_key = slab.leaf_nodes[boot_candidate as usize].key;
+            let boot_candidate_price = LeafNode::price_from_key(boot_candidate_key);
+            let should_boot = match side {
+                Side::Bid => boot_candidate_price < limit_price,
+                Side::Ask => boot_candidate_price > limit_price,
+            };
+            if should_boot {
+                let (order, callback_info_booted) = slab.remove_by_key(boot_candidate_key).unwrap();
+                let out = OutEvent {
+                    side: side as u8,
+                    order_id: order.order_id(),
+                    base_size: order.base_quantity,
+                    tag: EventTag::Out as u8,
+                    _padding: [0; 14],
+                };
+                event_queue
+                    .push_back(out, Some(callback_info_booted), None)
+                    .map_err(|_| AoError::EventQueueFull)?;
+                slab.insert_leaf(&new_leaf).unwrap().0
+            } else {
+                return Ok(OrderSummary {
+                    posted_order_id: None,
+                    total_base_qty: max_base_qty,
+                    total_quote_qty: max_quote_qty,
+                    total_base_qty_posted: 0,
+                });
+            }
+        } else {
+            insert_result.unwrap().0
+        };
+
+        *self.get_tree(side).get_callback_info_mut(k) = callback_info;
+        Ok(OrderSummary {
+            posted_order_id: Some(new_leaf_order_id),
+            total_base_qty: max_base_qty,
+            total_quote_qty: max_quote_qty,
+            total_base_qty_posted: base_qty_to_post,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/program/src/state/orderbook.rs
+++ b/program/src/state/orderbook.rs
@@ -405,6 +405,14 @@ where
             total_base_qty_posted: base_qty_to_post,
         })
     }
+
+    pub fn match_existing_orders(
+        &mut self,
+        event_queue: &mut EventQueue<'a, C>,
+        min_base_order_size: u64,
+    ) -> Result<u32, AoError> {
+        Ok(0)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
To facilitate a limited release of the program, allow for pausing and subsequent resuming of the orderbook matching engine.